### PR TITLE
Call AddHttpContextAccessor() by default

### DIFF
--- a/src/Istio.Tracing.Propagation.AspNetCore/ConfigureHostBuilderExtensions.cs
+++ b/src/Istio.Tracing.Propagation.AspNetCore/ConfigureHostBuilderExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Http;
 using Istio.Tracing.Propagation;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Http;
 
 namespace Microsoft.AspNetCore.Hosting
 {
@@ -23,6 +24,8 @@ namespace Microsoft.AspNetCore.Hosting
 
             return hostBuilder.ConfigureServices((services) =>
             {
+                services.AddHttpContextAccessor();
+
                 services.TryAddTransient<IstioHeadersFetcherMiddleware>();
                 services.TryAddTransient<HeadersPropagationDelegatingHandler>();
 

--- a/src/Istio.Tracing.Propagation.AspNetCore/Istio.Tracing.Propagation.AspNetCore.csproj
+++ b/src/Istio.Tracing.Propagation.AspNetCore/Istio.Tracing.Propagation.AspNetCore.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />

--- a/test/Istio.Tracing.Propagation.IntegrationTests/FakeServerStartup.cs
+++ b/test/Istio.Tracing.Propagation.IntegrationTests/FakeServerStartup.cs
@@ -20,7 +20,6 @@ namespace Istio.Tracing.Propagation.IntegrationTests
                 {
                     return provider.GetRequiredService<TestHttpMessageHandler>();
                 });
-            services.AddHttpContextAccessor();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/test/Istio.Tracing.Propagation.Tests/ConfigureHostBuilderExtensionsTests.cs
+++ b/test/Istio.Tracing.Propagation.Tests/ConfigureHostBuilderExtensionsTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Http;
 using Moq;
@@ -30,12 +31,13 @@ namespace Istio.Tracing.Propagation.Tests
             var serviceCollection = new MockServiceCollection();
             configActionPassed(serviceCollection);
 
-            Assert.Equal(5, serviceCollection.Count);
+            Assert.Equal(6, serviceCollection.Count);
             Assert.Equal(1, serviceCollection.Count(d => d.ServiceType == typeof(IstioHeadersFetcherMiddleware) && d.Lifetime == ServiceLifetime.Transient));
             Assert.Equal(1, serviceCollection.Count(d => d.ServiceType == typeof(HeadersPropagationDelegatingHandler) && d.Lifetime == ServiceLifetime.Transient));
             Assert.Equal(1, serviceCollection.Count(d => d.ServiceType == typeof(IIstioHeadersHolder) && d.ImplementationType == typeof(IstioHeadersHolder) && d.Lifetime == ServiceLifetime.Scoped));
             Assert.Equal(1, serviceCollection.Count(d => d.ServiceType == typeof(IStartupFilter) && d.ImplementationType == typeof(IstioHeadersFetcherMiddlewareStartupFilter) && d.Lifetime == ServiceLifetime.Singleton));
             Assert.Equal(1, serviceCollection.Count(d => d.ServiceType == typeof(IHttpMessageHandlerBuilderFilter) && d.ImplementationType == typeof(HeadersPropagationMessageHandlerBuilderFilter) && d.Lifetime == ServiceLifetime.Singleton));
+            Assert.Equal(1, serviceCollection.Count(d => d.ServiceType == typeof(IHttpContextAccessor) && d.ImplementationType == typeof(HttpContextAccessor) && d.Lifetime == ServiceLifetime.Singleton));
         }
 
         [Fact]


### PR DESCRIPTION
Fixes #3 by adding the httpcontextaccessor implementation to the configured services.